### PR TITLE
fix(vulnerabilities) : fix go lang vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/a8m/envsubst
 
-go 1.24.2
+go 1.24.4


### PR DESCRIPTION
bumped up golang to v1.24.4 for CVE-2025-4673 , CVE-2025-0913 and CVE-2025-22874