### PR TITLE
bump go to v1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/a8m/envsubst
 
-go 1.26.0
+go 1.26.1


### PR DESCRIPTION
https://www.cve.org/CVERecord?id=CVE-2026-27139