### PR TITLE
upgrade golang to v1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/a8m/envsubst
 
-go 1.26.3
+go 1.26.4


### PR DESCRIPTION
Common occurrence.  Related to the avoidance of CVE advisories when the tool is used.

This is more about the upgrade to v1.26.4 forcing a rebuild which should fetch the latest modules.  There are multiple modules with advisories, like `x/crypto` and `x/net`.

Maybe those should be called out in the go.mod individually??